### PR TITLE
Rendre le notebook accessible sur Onyxia

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,0 @@
-name: ml-environment
-dependencies:
-  - matplotlib
-  - numpy
-  - scikit-learn

--- a/onyxia.sh
+++ b/onyxia.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+REPO_URL=https://github.com/jmbernabotto/MachineLearning.git
+IPYNB_PATH=matrice_de_confusion_ROC_AUC.ipynb
+
+# Clone the repository in /home/jovyan/work
+git clone $REPO_URL /home/jovyan/work
+
+# Install dependencies
+[ -f /home/jovyan/work/requirements.txt ] && pip install -r /home/jovyan/work/requirements.txt
+
+# Open a given notebook
+[ -z "$IPYNB_PATH" ] || echo "\nc.NotebookApp.default_url = '/tree/work/${IPYNB_PATH}'" >> /home/jovyan/.jupyter/jupyter_notebook_config.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib
+numpy
+scikit-learn


### PR DESCRIPTION
Salut,

Comme je te l'avais dit, voici une petite surprise préparée avec @fcomte.

L'objectif de cette pull request est de rendre ton notebook accessible de façon interactive sur Onyxia : ça donnera exactement le même résultat qu'avec Binder (Binder fonctionnera toujours).  
Si tu veux regarder le résultat, voici un lien pour tester <https://spyrales.sspcloud.fr/my-lab/catalogue/inseefrlab-datascience/jupyter/deploiement?script.uri=https://raw.githubusercontent.com/RLesur/MachineLearning/onyxia/onyxia.sh>

@fcomte est en train de créer une rubrique pour les cours/formations/tutos sur Onyxia : est-ce que ça te dit qu'il soit également accessible dans cette rubrique ?

C'est une première ! J'espère que tu seras d'accord :smiley: 